### PR TITLE
Rename namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library brings the ease of Artisan commands and the power of Symfony consol
 
 Require the package:
 ```
-composer require ostark/yii2-artisan-bridge
+composer require fortrabbit/yii2-artisan-bridge
 ```
 
 ### Configure actions for a Craft 5 plugin
@@ -15,8 +15,8 @@ composer require ostark/yii2-artisan-bridge
 
 use Craft;
 use craft\base\Plugin as BasePlugin;
-use ostark\Yii2ArtisanBridge\ActionGroup;
-use ostark\Yii2ArtisanBridge\Bridge;
+use fortrabbit\Yii2ArtisanBridge\ActionGroup;
+use fortrabbit\Yii2ArtisanBridge\Bridge;
 use you\PluginName\actions\ActionOne;
 use you\PluginName\actions\ActionTwo;
 
@@ -65,7 +65,7 @@ it must be declared as a public property in the Action class.
 <?php namespace you\PluginName\actions;
 
 use Craft;
-use ostark\Yii2ArtisanBridge\base\Action as BaseAction;
+use fortrabbit\Yii2ArtisanBridge\base\Action as BaseAction;
 use yii\console\ExitCode;
 
 class ActionOne extends BaseAction {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "autoload": {
     "psr-4": {
-      "ostark\\Yii2ArtisanBridge\\": "src/"
+      "fortrabbit\\Yii2ArtisanBridge\\": "src/"
     }
   }
 }

--- a/src/ActionGroup.php
+++ b/src/ActionGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge;
+namespace fortrabbit\Yii2ArtisanBridge;
 
 class ActionGroup
 {

--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge;
+namespace fortrabbit\Yii2ArtisanBridge;
 
-use ostark\Yii2ArtisanBridge\base\Commands;
+use fortrabbit\Yii2ArtisanBridge\base\Commands;
 
 class Bridge
 {

--- a/src/ConsoleOutput.php
+++ b/src/ConsoleOutput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge;
+namespace fortrabbit\Yii2ArtisanBridge;
 
 class ConsoleOutput extends \Symfony\Component\Console\Output\ConsoleOutput
 {

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge;
+namespace fortrabbit\Yii2ArtisanBridge;
 
 use Symfony\Component\Console\Input\ArgvInput;
 use yii\console\UnknownCommandException;
@@ -9,7 +9,7 @@ use yii\console\UnknownCommandException;
 /**
  * Symfony console I/O
  *
- * @package ostark\Yii2ArtisanBridge
+ * @package fortrabbit\Yii2ArtisanBridge
  */
 class ErrorHandler extends \yii\console\ErrorHandler
 {

--- a/src/OutputStyle.php
+++ b/src/OutputStyle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge;
+namespace fortrabbit\Yii2ArtisanBridge;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 

--- a/src/base/Action.php
+++ b/src/base/Action.php
@@ -1,20 +1,20 @@
-<?php namespace ostark\Yii2ArtisanBridge\base;
+<?php namespace fortrabbit\Yii2ArtisanBridge\base;
 
-use ostark\Yii2ArtisanBridge\ConsoleOutput;
-use ostark\Yii2ArtisanBridge\OutputStyle;
+use fortrabbit\Yii2ArtisanBridge\ConsoleOutput;
+use fortrabbit\Yii2ArtisanBridge\OutputStyle;
 use Symfony\Component\Console\Input\ArgvInput;
 use yii\base\Action as YiiBaseAction;
 
 /**
  * Class Action
  *
- * @package ostark\Yii2ArtisanBridge\base
+ * @package fortrabbit\Yii2ArtisanBridge\base
  *
  */
 abstract class Action extends YiiBaseAction
 {
     /**
-     * @var \ostark\Yii2ArtisanBridge\OutputStyle
+     * @var \fortrabbit\Yii2ArtisanBridge\OutputStyle
      */
 
     protected $output;
@@ -42,7 +42,7 @@ abstract class Action extends YiiBaseAction
      * Action constructor.
      *
      * @param string               $id
-     * @param \ostark\Yii2ArtisanBridge\base\Commands $controller
+     * @param \fortrabbit\Yii2ArtisanBridge\base\Commands $controller
      * @param array                $config
      */
     public function __construct(string $id, Commands $controller, array $config = [])

--- a/src/base/ArtisanOutputTrait.php
+++ b/src/base/ArtisanOutputTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge\base;
+namespace fortrabbit\Yii2ArtisanBridge\base;
 
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,8 +14,8 @@ use yii\base\Arrayable;
  * Borrowed from Illuminate\Console\Command
  * @see https://github.com/laravel/framework/blob/5.6/src/Illuminate/Console/Command.php
  *
- * @property \ostark\Yii2ArtisanBridge\ConsoleOutput $input
- * @property \ostark\Yii2ArtisanBridge\OutputStyle  $output
+ * @property \fortrabbit\Yii2ArtisanBridge\ConsoleOutput $input
+ * @property \fortrabbit\Yii2ArtisanBridge\OutputStyle  $output
  *
  */
 trait ArtisanOutputTrait

--- a/src/base/BlockOutputTrait.php
+++ b/src/base/BlockOutputTrait.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge\base;
+namespace fortrabbit\Yii2ArtisanBridge\base;
 
 /**
  * Trait BlockOutputTrait
  *
- * @property \ostark\Yii2ArtisanBridge\ConsoleOutput $input
- * @property \ostark\Yii2ArtisanBridge\OutputStyle  $output
+ * @property \fortrabbit\Yii2ArtisanBridge\ConsoleOutput $input
+ * @property \fortrabbit\Yii2ArtisanBridge\OutputStyle  $output
  */
 trait BlockOutputTrait
 {

--- a/src/base/Commands.php
+++ b/src/base/Commands.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace ostark\Yii2ArtisanBridge\base;
+namespace fortrabbit\Yii2ArtisanBridge\base;
 
-use ostark\Yii2ArtisanBridge\ErrorHandler;
+use fortrabbit\Yii2ArtisanBridge\ErrorHandler;
 use Yii;
 use yii\base\ActionEvent;
 use yii\console\Controller as BaseConsoleController;


### PR DESCRIPTION
Since we've now forked completely and intend to maintain this version independently, this PR changes the PSR-4 namespace from `ostark` to `fortrabbit`.